### PR TITLE
Add RCOT-style two-stage DMAE

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,16 @@ The fine-tuning and evaluation instruction is in [FINETUNE.md](FINETUNE.md).
 
 ### License
 This project is under the CC-BY-NC 4.0 license. See [LICENSE](LICENSE) for details.
+
+### Residual Two-Stage DMAE
+The repository also provides an example implementation of a residual conditioned two-stage DMAE model inspired by RCOT. The new modules are defined in `models_rcot.py` and a simple pre-training script `main_rcot_pretrain.py` is included.
+
+To pre-train the two-stage model using the released DMAE-Base weights run
+```bash
+python main_rcot_pretrain.py \
+  --pretrained PATH_TO_DMAE_BASE_WEIGHTS \
+  --data_path PATH_TO_IMAGENET \
+  --output_dir rcot_pretrain \
+  --epochs 100
+```
+After pre-training, the checkpoint can be fine-tuned or certified following the instructions in [FINETUNE.md](FINETUNE.md) by specifying `--finetune` with the new checkpoint path.

--- a/engine_twostage.py
+++ b/engine_twostage.py
@@ -1,0 +1,73 @@
+import math
+import sys
+from typing import Iterable
+import torch
+import torch.nn.functional as F
+import torchvision.transforms as transforms
+import PIL
+
+import util.misc as misc
+import util.lr_sched as lr_sched
+
+
+def train_one_epoch(model: torch.nn.Module,
+                    data_loader: Iterable,
+                    optimizer: torch.optim.Optimizer,
+                    device: torch.device,
+                    epoch: int,
+                    loss_scaler,
+                    log_writer=None,
+                    args=None):
+    model.train(True)
+    metric_logger = misc.MetricLogger(delimiter="  ")
+    metric_logger.add_meter('lr', misc.SmoothedValue(window_size=1, fmt='{value:.6f}'))
+    header = 'Epoch: [{}]'.format(epoch)
+    print_freq = 20
+
+    accum_iter = args.accum_iter
+    optimizer.zero_grad()
+
+    if log_writer is not None:
+        print('log_dir: {}'.format(log_writer.log_dir))
+
+    for data_iter_step, (samples, _) in enumerate(metric_logger.log_every(data_loader, print_freq, header)):
+        if data_iter_step % accum_iter == 0:
+            lr_sched.adjust_learning_rate(optimizer, data_iter_step / len(data_loader) + epoch, args)
+
+        samples = samples.to(device, non_blocking=True)
+        clean = transforms.Resize((args.input_size, args.input_size), interpolation=PIL.Image.BICUBIC)(samples)
+        noise = torch.randn_like(clean) * args.sigma
+        noisy = clean + noise
+
+        with torch.cuda.amp.autocast():
+            x_hat, x_refined = model(noisy, clean)
+            loss1 = F.mse_loss(x_hat, clean)
+            loss2 = F.mse_loss(x_refined, clean)
+            loss = loss2 + args.lambda_stage1 * loss1
+
+        loss_value = loss.item()
+        if not math.isfinite(loss_value):
+            print("Loss is {}, stopping training".format(loss_value))
+            sys.exit(1)
+
+        loss /= accum_iter
+        loss_scaler(loss, optimizer, parameters=model.parameters(),
+                    update_grad=(data_iter_step + 1) % accum_iter == 0)
+        if (data_iter_step + 1) % accum_iter == 0:
+            optimizer.zero_grad()
+
+        torch.cuda.synchronize()
+
+        metric_logger.update(loss=loss_value)
+        lr = optimizer.param_groups[0]["lr"]
+        metric_logger.update(lr=lr)
+
+        loss_value_reduce = misc.all_reduce_mean(loss_value)
+        if log_writer is not None and (data_iter_step + 1) % accum_iter == 0:
+            epoch_1000x = int((data_iter_step / len(data_loader) + epoch) * 1000)
+            log_writer.add_scalar('train_loss', loss_value_reduce, epoch_1000x)
+            log_writer.add_scalar('lr', lr, epoch_1000x)
+
+    metric_logger.synchronize_between_processes()
+    print("Averaged stats:", metric_logger)
+    return {k: meter.global_avg for k, meter in metric_logger.meters.items()}

--- a/main_rcot_pretrain.py
+++ b/main_rcot_pretrain.py
@@ -1,0 +1,178 @@
+import argparse
+import datetime
+import json
+import os
+import time
+from pathlib import Path
+
+import torch
+import torch.backends.cudnn as cudnn
+from torch.utils.tensorboard import SummaryWriter
+import torchvision.transforms as transforms
+import torchvision.datasets as datasets
+
+import timm.optim.optim_factory as optim_factory
+
+import util.misc as misc
+from util.misc import NativeScalerWithGradNormCount as NativeScaler
+
+import models_dmae
+import models_rcot
+
+from engine_twostage import train_one_epoch
+
+
+def get_args_parser():
+    parser = argparse.ArgumentParser('Two-stage DMAE pre-training', add_help=False)
+    parser.add_argument('--batch_size', default=64, type=int,
+                        help='Batch size per GPU')
+    parser.add_argument('--epochs', default=100, type=int)
+    parser.add_argument('--accum_iter', default=1, type=int,
+                        help='Accumulate gradient iterations')
+
+    parser.add_argument('--model', default='dmae_vit_base_patch16', type=str,
+                        metavar='MODEL', help='Name of DMAE model')
+    parser.add_argument('--pretrained', type=str, required=True,
+                        help='Path to DMAE pre-trained checkpoint')
+
+    parser.add_argument('--input_size', default=224, type=int,
+                        help='images input size')
+    parser.add_argument('--sigma', default=0.25, type=float,
+                        help='Std of Gaussian noise')
+    parser.add_argument('--lambda_stage1', default=0.5, type=float,
+                        help='loss weight for stage1 output')
+
+    parser.add_argument('--weight_decay', type=float, default=0.05,
+                        help='weight decay')
+
+    parser.add_argument('--lr', type=float, default=None, metavar='LR',
+                        help='learning rate (absolute lr)')
+    parser.add_argument('--blr', type=float, default=1e-3, metavar='LR',
+                        help='base learning rate')
+    parser.add_argument('--min_lr', type=float, default=1e-4, metavar='LR',
+                        help='lower lr bound for cyclic schedulers that hit 0')
+
+    parser.add_argument('--warmup_epochs', type=int, default=5, metavar='N',
+                        help='epochs to warmup LR')
+
+    parser.add_argument('--data_path', default='path_to_imagenet', type=str,
+                        help='dataset path')
+    parser.add_argument('--output_dir', default='.', type=str,
+                        help='path where to save logs and checkpoints')
+    parser.add_argument('--log_dir', default=None, type=str,
+                        help='path where to tensorboard log')
+    parser.add_argument('--device', default='cuda', help='device to use for training')
+    parser.add_argument('--seed', default=0, type=int)
+    parser.add_argument('--num_workers', default=10, type=int)
+    parser.add_argument('--pin_mem', action='store_true')
+    parser.add_argument('--no_pin_mem', action='store_false', dest='pin_mem')
+    parser.set_defaults(pin_mem=True)
+
+    parser.add_argument('--resume', default='', help='resume from checkpoint')
+    parser.add_argument('--start_epoch', default=0, type=int, metavar='N',
+                        help='start epoch')
+
+    return parser
+
+
+def main(args):
+    misc.init_distributed_mode(args)
+
+    print('job dir: {}'.format(os.path.dirname(os.path.realpath(__file__))))
+    print("{}".format(args).replace(', ', ',\n'))
+
+    device = torch.device(args.device)
+
+    seed = args.seed + misc.get_rank()
+    torch.manual_seed(seed)
+    cudnn.benchmark = True
+
+    transform_train = transforms.Compose([
+        transforms.RandomResizedCrop(args.input_size, scale=(0.2, 1.0), interpolation=3),
+        transforms.RandomHorizontalFlip(),
+        transforms.ToTensor(),
+    ])
+    dataset_train = datasets.ImageFolder(os.path.join(args.data_path, 'train'), transform=transform_train)
+    if True:
+        num_tasks = misc.get_world_size()
+        global_rank = misc.get_rank()
+        sampler_train = torch.utils.data.DistributedSampler(
+            dataset_train, num_replicas=num_tasks, rank=global_rank, shuffle=True
+        )
+    else:
+        sampler_train = torch.utils.data.RandomSampler(dataset_train)
+
+    if misc.is_main_process() and args.log_dir is not None:
+        os.makedirs(args.log_dir, exist_ok=True)
+        log_writer = SummaryWriter(log_dir=args.log_dir)
+    else:
+        log_writer = None
+
+    data_loader_train = torch.utils.data.DataLoader(
+        dataset_train, sampler=sampler_train,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        pin_memory=args.pin_mem,
+        drop_last=True,
+    )
+
+    base_model = models_dmae.__dict__[args.model](norm_pix_loss=False, sigma=args.sigma)
+    checkpoint = torch.load(args.pretrained, map_location='cpu')
+    base_model.load_state_dict(checkpoint['model'], strict=False)
+
+    res_encoder = models_rcot.ResidualEncoder(in_channels=3, embed_dim=512)
+    decoder2 = models_rcot.ConditionalDecoder(embed_dim=512, num_layers=8, num_heads=16, cond_dim=512,
+                                              patch_size=16, image_size=args.input_size)
+    model = models_rcot.TwoStageDMAE(base_model, decoder2, res_encoder)
+    model.to(device)
+    model_without_ddp = model
+
+    eff_batch_size = args.batch_size * args.accum_iter * misc.get_world_size()
+    if args.lr is None:
+        args.lr = args.blr * eff_batch_size / 256
+    if args.distributed:
+        model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[args.gpu])
+        model_without_ddp = model.module
+
+    param_groups = optim_factory.add_weight_decay(model_without_ddp, args.weight_decay)
+    optimizer = torch.optim.AdamW(param_groups, lr=args.lr, betas=(0.9, 0.95))
+    loss_scaler = NativeScaler()
+
+    misc.load_model(args=args, model_without_ddp=model_without_ddp, optimizer=optimizer, loss_scaler=loss_scaler)
+
+    print(f"Start training for {args.epochs} epochs")
+    start_time = time.time()
+    for epoch in range(args.start_epoch, args.epochs):
+        if args.distributed:
+            data_loader_train.sampler.set_epoch(epoch)
+        train_stats = train_one_epoch(
+            model, data_loader_train,
+            optimizer, device, epoch, loss_scaler,
+            log_writer=log_writer,
+            args=args
+        )
+        if args.output_dir and (epoch % 20 == 0 or epoch + 1 == args.epochs):
+            misc.save_model(
+                args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
+                loss_scaler=loss_scaler, epoch=epoch)
+
+        log_stats = {**{f'train_{k}': v for k, v in train_stats.items()},
+                        'epoch': epoch,}
+
+        if args.output_dir and misc.is_main_process():
+            if log_writer is not None:
+                log_writer.flush()
+            with open(os.path.join(args.output_dir, "log.txt"), mode="a", encoding="utf-8") as f:
+                f.write(json.dumps(log_stats) + "\n")
+
+    total_time = time.time() - start_time
+    total_time_str = str(datetime.timedelta(seconds=int(total_time)))
+    print('Training time {}'.format(total_time_str))
+
+
+if __name__ == '__main__':
+    args = get_args_parser()
+    args = args.parse_args()
+    if args.output_dir:
+        Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+    main(args)

--- a/models_rcot.py
+++ b/models_rcot.py
@@ -1,0 +1,141 @@
+import torch
+import torch.nn as nn
+from typing import Optional
+
+
+class ResidualEncoder(nn.Module):
+    """Encode residual images into a conditioning embedding."""
+
+    def __init__(self, in_channels: int = 3, embed_dim: int = 512):
+        super().__init__()
+        self.conv1 = nn.Conv2d(in_channels, 32, kernel_size=3, stride=2, padding=1)
+        self.bn1 = nn.BatchNorm2d(32)
+        self.conv2 = nn.Conv2d(32, 64, kernel_size=3, stride=2, padding=1)
+        self.bn2 = nn.BatchNorm2d(64)
+        self.conv3 = nn.Conv2d(64, 128, kernel_size=3, stride=2, padding=1)
+        self.bn3 = nn.BatchNorm2d(128)
+        self.pool = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = nn.Linear(128, embed_dim)
+        self.act = nn.GELU()
+
+    def forward(self, r: torch.Tensor) -> torch.Tensor:
+        x = torch.relu(self.bn1(self.conv1(r)))
+        x = torch.relu(self.bn2(self.conv2(x)))
+        x = torch.relu(self.bn3(self.conv3(x)))
+        x = self.pool(x).view(x.size(0), -1)
+        e = self.act(self.fc(x))
+        return e
+
+
+class FiLMBlock(nn.Module):
+    """Feature-wise linear modulation."""
+
+    def __init__(self, cond_dim: int, feat_dim: int):
+        super().__init__()
+        self.gamma_fc = nn.Linear(cond_dim, feat_dim)
+        self.beta_fc = nn.Linear(cond_dim, feat_dim)
+
+    def forward(self, cond: torch.Tensor, features: torch.Tensor) -> torch.Tensor:
+        gamma = self.gamma_fc(cond)
+        beta = self.beta_fc(cond)
+        if features.dim() == 3:
+            gamma = gamma.unsqueeze(1)
+            beta = beta.unsqueeze(1)
+        return features * gamma + beta
+
+
+class ConditionalTransformerBlock(nn.Module):
+    """Transformer block with FiLM conditioning."""
+
+    def __init__(self, embed_dim: int, num_heads: int, mlp_ratio: float = 4.0, cond_dim: Optional[int] = None):
+        super().__init__()
+        cond_dim = cond_dim if cond_dim is not None else embed_dim
+        self.norm1 = nn.LayerNorm(embed_dim)
+        self.norm2 = nn.LayerNorm(embed_dim)
+        self.attn = nn.MultiheadAttention(embed_dim, num_heads, batch_first=True)
+        hidden_dim = int(embed_dim * mlp_ratio)
+        self.ffn = nn.Sequential(
+            nn.Linear(embed_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, embed_dim),
+        )
+        self.film = FiLMBlock(cond_dim, embed_dim)
+
+    def forward(self, x: torch.Tensor, cond: Optional[torch.Tensor] = None) -> torch.Tensor:
+        attn_out, _ = self.attn(self.norm1(x), self.norm1(x), self.norm1(x))
+        x = x + attn_out
+        ffn_out = self.ffn(self.norm2(x))
+        x = x + ffn_out
+        if cond is not None:
+            x = self.film(cond, x)
+        return x
+
+
+class ConditionalDecoder(nn.Module):
+    """Transformer decoder that uses FiLM conditioning from residual embedding."""
+
+    def __init__(
+        self,
+        embed_dim: int = 512,
+        num_layers: int = 8,
+        num_heads: int = 16,
+        mlp_ratio: float = 4.0,
+        cond_dim: Optional[int] = None,
+        patch_size: int = 16,
+        image_size: int = 224,
+    ) -> None:
+        super().__init__()
+        self.embed_dim = embed_dim
+        num_patches = (image_size // patch_size) ** 2
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches + 1, embed_dim))
+        self.blocks = nn.ModuleList(
+            [
+                ConditionalTransformerBlock(embed_dim, num_heads, mlp_ratio, cond_dim)
+                for _ in range(num_layers)
+            ]
+        )
+        self.norm = nn.LayerNorm(embed_dim)
+        self.patch_size = patch_size
+        self.out_proj = nn.Linear(embed_dim, patch_size * patch_size * 3)
+
+    def forward(self, latent_tokens: torch.Tensor, cond: torch.Tensor) -> torch.Tensor:
+        x = latent_tokens + self.pos_embed[:, : latent_tokens.size(1), :]
+        for block in self.blocks:
+            x = block(x, cond)
+        x = self.norm(x)
+        patch_pixels = self.out_proj(x)
+        B, N, _ = patch_pixels.shape
+        patches_per_side = int(N ** 0.5)
+        out = patch_pixels.view(B, patches_per_side, patches_per_side, self.patch_size, self.patch_size, 3)
+        out = out.permute(0, 5, 1, 3, 2, 4).contiguous()
+        out_image = out.view(B, 3, patches_per_side * self.patch_size, patches_per_side * self.patch_size)
+        return out_image
+
+
+class TwoStageDMAE(nn.Module):
+    """Wrap DMAE with residual conditioned second stage decoder."""
+
+    def __init__(self, base_model: nn.Module, decoder2: ConditionalDecoder, res_encoder: ResidualEncoder) -> None:
+        super().__init__()
+        self.base = base_model
+        self.decoder2 = decoder2
+        self.res_encoder = res_encoder
+        self.mean = self.base.mean
+        self.std = self.base.std
+
+    def forward(self, x_noisy: torch.Tensor, x_clean: Optional[torch.Tensor] = None):
+        if self.mean.device != x_noisy.device:
+            self.mean = self.mean.to(x_noisy.device)
+            self.std = self.std.to(x_noisy.device)
+        x_noisy = (x_noisy - self.mean) / self.std
+        if x_clean is not None:
+            x_clean = (x_clean - self.mean) / self.std
+        latent, _, ids_restore = self.base.forward_encoder(x_noisy, mask_ratio=0.0)
+        pred = self.base.forward_decoder(latent, ids_restore)
+        x_hat = self.base.unpatchify(pred)
+        residual = (x_clean if x_clean is not None else x_noisy) - x_hat
+        e = self.res_encoder(residual)
+        refined = self.decoder2(latent[:, 1:, :], e)
+        x_hat = x_hat * self.std + self.mean
+        refined = refined * self.std + self.mean
+        return x_hat, refined


### PR DESCRIPTION
## Summary
- implement residual two‑stage DMAE modules in `models_rcot.py`
- add training engine `engine_twostage.py`
- provide sample pretraining script `main_rcot_pretrain.py`
- document workflow in README

## Testing
- `python -m py_compile models_rcot.py engine_twostage.py main_rcot_pretrain.py`

------
https://chatgpt.com/codex/tasks/task_e_6841295d01fc8330b6fe7568d577b55f